### PR TITLE
wrap jobs in the pipeline under same connect

### DIFF
--- a/src/dagger/jobs.ts
+++ b/src/dagger/jobs.ts
@@ -18,22 +18,21 @@ export const exclude = ["vendor", ".git"];
  * @returns {Directory | string}
  */
 export async function test(
-  src: Directory | string | undefined = "."
+  client: Client,
+  src: Directory | string | undefined = ".",
 ): Promise<string> {
   let result = "";
-  await connect(async (client: Client) => {
-    const context = getDirectory(client, src);
-    const ctr = client
-      .pipeline(Job.test)
-      .container()
-      .from("golang:latest")
-      .withDirectory("/app", context, { exclude })
-      .withWorkdir("/app")
-      .withMountedCache("/go/pkg/mod", client.cacheVolume("go-mod"))
-      .withMountedCache("/root/.cache/go-build", client.cacheVolume("go-build"))
-      .withExec(["go", "test", "-v", "./..."]);
-    result = await ctr.stdout();
-  });
+  const context = getDirectory(client, src);
+  const ctr = client
+    .pipeline(Job.test)
+    .container()
+    .from("golang:latest")
+    .withDirectory("/app", context, { exclude })
+    .withWorkdir("/app")
+    .withMountedCache("/go/pkg/mod", client.cacheVolume("go-mod"))
+    .withMountedCache("/root/.cache/go-build", client.cacheVolume("go-build"))
+    .withExec(["go", "test", "-v", "./..."]);
+  result = await ctr.stdout();
   return result;
 }
 
@@ -44,25 +43,22 @@ export async function test(
  * @returns {Directory | string}
  */
 export async function fmt(
-  src: Directory | string | undefined = "."
+  client: Client,
+  src: Directory | string | undefined = ".",
 ): Promise<Directory | string> {
   let id = "";
-  await connect(async (client: Client) => {
-    const context = getDirectory(client, src);
-    const ctr = client
-      .pipeline(Job.fmt)
-      .container()
-      .from("golang:latest")
-      .withDirectory("/app", context, { exclude })
-      .withMountedCache("/go/pkg/mod", client.cacheVolume("go-mod"))
-      .withMountedCache("/root/.cache/go-build", client.cacheVolume("go-build"))
-      .withWorkdir("/app")
-
-      .withExec(["go", "fmt", "./..."]);
-    await ctr.stdout();
-    id = await ctr.directory("/app/").id();
-  });
-  return id;
+  const context = getDirectory(client, src);
+  const ctr = client
+    .pipeline(Job.fmt)
+    .container()
+    .from("golang:latest")
+    .withDirectory("/app", context, { exclude })
+    .withMountedCache("/go/pkg/mod", client.cacheVolume("go-mod"))
+    .withMountedCache("/root/.cache/go-build", client.cacheVolume("go-build"))
+    .withWorkdir("/app")
+    .withExec(["go", "fmt", "./..."]);
+  await ctr.stdout();
+  return await ctr.directory("/app/").id();
 }
 
 /**
@@ -72,28 +68,27 @@ export async function fmt(
  * @returns {Directory | string}
  */
 export async function build(
-  src: Directory | string | undefined = "."
+  client: Client,
+  src: Directory | string | undefined = ".",
 ): Promise<Directory | string> {
   let id = "";
-  await connect(async (client: Client) => {
-    const context = getDirectory(client, src);
-    const ctr = client
-      .pipeline(Job.build)
-      .container()
-      .from("golang:latest")
-      .withDirectory("/app", context, { exclude })
-      .withWorkdir("/app")
-      .withMountedCache("/go/pkg/mod", client.cacheVolume("go-mod"))
-      .withMountedCache("/root/.cache/go-build", client.cacheVolume("go-build"))
-      .withExec(["go", "build"]);
-    await ctr.stdout();
-    id = await ctr.directory("/app/").id();
-  });
-  return id;
+  const context = getDirectory(client, src);
+  const ctr = client
+    .pipeline(Job.build)
+    .container()
+    .from("golang:latest")
+    .withDirectory("/app", context, { exclude })
+    .withWorkdir("/app")
+    .withMountedCache("/go/pkg/mod", client.cacheVolume("go-mod"))
+    .withMountedCache("/root/.cache/go-build", client.cacheVolume("go-build"))
+    .withExec(["go", "build"]);
+  await ctr.stdout();
+  return await ctr.directory("/app/").id();
 }
 
 export type JobExec = (
-  src: Directory | string | undefined
+  client: Client,
+  src: Directory | string | undefined,
 ) => Promise<Directory | string>;
 
 export const runnableJobs: Record<Job, JobExec> = {

--- a/src/dagger/pipeline.ts
+++ b/src/dagger/pipeline.ts
@@ -1,4 +1,6 @@
 import { uploadContext } from "../../deps.ts";
+import { connect } from "../../sdk/connect.ts";
+import { Client } from "../../sdk/client.gen.ts";
 import * as jobs from "./jobs.ts";
 
 const { build, fmt, test, exclude } = jobs;
@@ -12,18 +14,22 @@ export default async function pipeline(src = ".", args: string[] = []) {
     return;
   }
 
-  await fmt(src);
-  await test(src);
-  await build(src);
+  await connect(async (client: Client) => {
+    await fmt(client, src);
+    await test(client, src);
+    await build(client, src);
+  });
 }
 
 async function runSpecificJobs(args: string[]) {
-  for (const name of args) {
-    // deno-lint-ignore no-explicit-any
-    const job = (jobs as any)[name];
-    if (!job) {
-      throw new Error(`Job ${name} not found`);
+  await connect(async (client: Client) => {
+    for (const name of args) {
+      // deno-lint-ignore no-explicit-any
+      const job = (jobs as any)[name];
+      if (!job) {
+        throw new Error(`Job ${name} not found`);
+      }
+      await job(client);
     }
-    await job();
-  }
+  });
 }


### PR DESCRIPTION
### Why?
When using dagger v0.9.5, the pipeline() only run the first job. In the case of the current pipeline only fmt was running.

### Solution
Wrap all jobs of the pipeline under the same connect function.